### PR TITLE
Ignore commented out test functions

### DIFF
--- a/bin/parse_tests.py
+++ b/bin/parse_tests.py
@@ -32,12 +32,14 @@ def parse_test_functions(s: str):
     in the test file
     """
     function_matches = re.finditer(
-        fr"\({TEST_FUNCTION}\s+(?P<name>[\w-]+)\s+\(\)\s*(?P<docstring>\".*\")?\s*(?P<code>(?:\n.+)+)\)",
+        fr"(?P<semicolons>;+)?\s*\({TEST_FUNCTION}\s+(?P<name>[\w-]+)\s+\(\)\s*(?P<docstring>\".*\")?\s*(?P<code>(?:\n.+)+)\)",
         s,
     )
     names = []
     code_pieces = []
     for m in function_matches:
+        if m["semicolons"]:
+            continue
         names.append(m["name"])
         code_pieces.append(m["code"].strip())
     return names, code_pieces

--- a/tests/example-commented/example-commented-test.el
+++ b/tests/example-commented/example-commented-test.el
@@ -1,0 +1,15 @@
+;;; leap-test.el --- Tests for Leap exercise (exercism)
+
+;;; Commentary:
+
+;;; Code:
+(load-file "example-commented.el")
+
+(ert-deftest vanilla-leap-year ()
+  (should (leap-year-p 1996)))
+
+;; (ert-deftest exceptional-century ()
+;;   (should (leap-year-p 2000)))
+
+(provide 'leap-test)
+;;; leap-test.el ends here

--- a/tests/example-commented/example-commented.el
+++ b/tests/example-commented/example-commented.el
@@ -1,0 +1,14 @@
+;;; leap.el --- Leap exercise (exercism)
+
+;;; Commentary:
+
+;;; Code:
+
+(defun leap-year-p (year)
+  "Determine if YEAR is a leap year."
+  (and (= 0 (mod year 4))
+       (or (not (= 0 (mod year 100)))
+           (= 0 (mod year 400)))))
+
+(provide 'leap)
+;;; leap.el ends here

--- a/tests/example-commented/expected_results.json
+++ b/tests/example-commented/expected_results.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "status": "pass",
+  "message": null,
+  "tests": [
+    {
+      "name": "vanilla-leap-year",
+      "test_code": "(should (leap-year-p 1996))",
+      "status": "pass",
+      "message": null
+    }
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/exercism/emacs-lisp-test-runner/issues/47

["your-birthday" test](https://github.com/exercism/emacs-lisp/blob/f456be6ee9c2ff766ef296602cc5aec3486daeea/exercises/practice/gigasecond/gigasecond-test.el#L38-L41) which is commented out wasn't ignored by interpreter