### PR TITLE
Activate lexical binding for test cases

### DIFF
--- a/tests/example-all-fail/example-all-fail-test.el
+++ b/tests/example-all-fail/example-all-fail-test.el
@@ -1,4 +1,4 @@
-;;; leap-test.el --- Tests for Leap exercise (exercism)
+;;; leap-test.el --- Tests for Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-all-fail/example-all-fail.el
+++ b/tests/example-all-fail/example-all-fail.el
@@ -1,4 +1,4 @@
-;;; leap.el --- Leap exercise (exercism)
+;;; leap.el --- Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-commented/example-commented-test.el
+++ b/tests/example-commented/example-commented-test.el
@@ -1,4 +1,4 @@
-;;; leap-test.el --- Tests for Leap exercise (exercism)
+;;; leap-test.el --- Tests for Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-commented/example-commented.el
+++ b/tests/example-commented/example-commented.el
@@ -1,4 +1,4 @@
-;;; leap.el --- Leap exercise (exercism)
+;;; leap.el --- Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-empty-file/example-empty-file-test.el
+++ b/tests/example-empty-file/example-empty-file-test.el
@@ -1,4 +1,4 @@
-;;; leap-test.el --- Tests for Leap exercise (exercism)
+;;; leap-test.el --- Tests for Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-output/example-output-test.el
+++ b/tests/example-output/example-output-test.el
@@ -1,4 +1,4 @@
-;;; leap-test.el --- Tests for Leap exercise (exercism)
+;;; leap-test.el --- Tests for Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-output/example-output.el
+++ b/tests/example-output/example-output.el
@@ -1,4 +1,4 @@
-;;; leap.el --- Leap exercise (exercism)
+;;; leap.el --- Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-partial-fail/example-partial-fail-test.el
+++ b/tests/example-partial-fail/example-partial-fail-test.el
@@ -1,4 +1,4 @@
-;;; leap-test.el --- Tests for Leap exercise (exercism)
+;;; leap-test.el --- Tests for Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-partial-fail/example-partial-fail.el
+++ b/tests/example-partial-fail/example-partial-fail.el
@@ -1,4 +1,4 @@
-;;; leap.el --- Leap exercise (exercism)
+;;; leap.el --- Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-success/example-success-test.el
+++ b/tests/example-success/example-success-test.el
@@ -1,4 +1,4 @@
-;;; leap-test.el --- Tests for Leap exercise (exercism)
+;;; leap-test.el --- Tests for Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-success/example-success.el
+++ b/tests/example-success/example-success.el
@@ -1,4 +1,4 @@
-;;; leap.el --- Leap exercise (exercism)
+;;; leap.el --- Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-syntax-error/example-syntax-error-test.el
+++ b/tests/example-syntax-error/example-syntax-error-test.el
@@ -1,4 +1,4 @@
-;;; leap-test.el --- Tests for Leap exercise (exercism)
+;;; leap-test.el --- Tests for Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/tests/example-syntax-error/example-syntax-error.el
+++ b/tests/example-syntax-error/example-syntax-error.el
@@ -1,1 +1,3 @@
+;;;  -*- lexical-binding: t; -*-
+
 DEF&*@#$

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "status": "error",
-  "message": "Loading /solution/example-syntax-error.el (source)...\r\nDebugger entered--Lisp error: (void-variable DEF&*@)\r\n  eval-buffer(#<buffer  > nil \"/solution/exampl...\" nil t)  ; Reading at buffer position 7\r\n  load-with-code-conversion(\"/solution/exampl...\" \"/solution/exampl...\" nil nil)\r\n  load(\"/solution/exampl...\" nil nil t)\r\n  load-file(\"example-syntax-error.el\")\r\n  eval-buffer(#<buffer  > nil \"/solution/exampl...\" nil t)  ; Reading at buffer position 122\r\n  load-with-code-conversion(\"/solution/exampl...\" \"/solution/exampl...\" nil t)\r\n  load(\"/solution/exampl...\" nil t)\r\n  command-line-1((\"-l\" \"ert\" \"-l\" \"/solution/exampl...\" \"-f\" \"ert-run-tests-batch-and-exit\"))\r\n  command-line()\r\n  normal-top-level()\r\n\r",
+  "message": "Loading /solution/example-syntax-error.el (source)...\r\nDebugger entered--Lisp error: (void-variable DEF&*@)\r\n  eval-buffer(#<buffer  > nil \"/solution/exampl...\" nil t)  ; Reading at buffer position 41\r\n  load-with-code-conversion(\"/solution/exampl...\" \"/solution/exampl...\" nil nil)\r\n  load(\"/solution/exampl...\" nil nil t)\r\n  load-file(\"example-syntax-error.el\")\r\n  eval-buffer(#<buffer  > nil \"/solution/exampl...\" nil t)  ; Reading at buffer position 151\r\n  load-with-code-conversion(\"/solution/exampl...\" \"/solution/exampl...\" nil t)\r\n  load(\"/solution/exampl...\" nil t)\r\n  command-line-1((\"-l\" \"ert\" \"-l\" \"/solution/exampl...\" \"-f\" \"ert-run-tests-batch-and-exit\"))\r\n  command-line()\r\n  normal-top-level()\r\n\r",
   "tests": [
     {
       "name": "vanilla-leap-year",


### PR DESCRIPTION
Following https://github.com/exercism/emacs-lisp/pull/221. All emacs-lisp code should use lexical binding.

See
- https://github.com/bbatsov/emacs-lisp-style-guide#source-code-layout--organization
- https://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html