### PR TITLE
Upgrade to Emacs 28.2 from nix-emacs-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM ubuntu:20.04
+FROM silex/emacs:28.2
 
 RUN apt-get update && \
     apt-get install -y curl jq software-properties-common
-
-RUN add-apt-repository ppa:kelleyk/emacs && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y emacs28
 
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get purge --auto-remove && \


### PR DESCRIPTION
Upgrades from Emacs 28.1 to 28.2 using a new installation method.

Since the ppa from kelleyk hasn't been updated in a while it's best to switch to a new installation method.

The new base image wraps nix-emacs-ci, that is already used in the [track CI workflow](https://github.com/exercism/emacs-lisp/blob/e00327acdfd7e79b7e9c2e2cb5b34915b1624473/.github/workflows/ci.yml#L14).

Docker image: https://github.com/Silex/docker-emacs/tree/master
nix-emacs-ci: https://github.com/purcell/nix-emacs-ci