### PR TITLE
Upgrade to Emacs 29.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM silex/emacs:28.2
+FROM silex/emacs:29.3
 
 RUN apt-get update && \
     apt-get install -y curl jq software-properties-common

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -30,6 +30,7 @@ for test_dir in tests/*; do
       -e "s~${test_dir_path}~/solution~g" \
       -e 's/\*load\*(\-[0-9]+)?//g' \
       -e 's/\([0-9]+\.[0-9]+ sec\)//g' \
+      -e 's/#<bytecode [^>]*>/#<bytecode >/' \
       "${results_file_path}"
 
     echo "${test_dir_name}: comparing results.json to expected_results.json"

--- a/tests/example-syntax-error/example-syntax-error-test.el
+++ b/tests/example-syntax-error/example-syntax-error-test.el
@@ -4,7 +4,6 @@
 
 ;;; Code:
 
-(setq backtrace-on-error-noninteractive nil)
 (load-file "example-syntax-error.el")
 
 (ert-deftest vanilla-leap-year ()

--- a/tests/example-syntax-error/example-syntax-error-test.el
+++ b/tests/example-syntax-error/example-syntax-error-test.el
@@ -3,6 +3,8 @@
 ;;; Commentary:
 
 ;;; Code:
+
+(setq backtrace-on-error-noninteractive nil)
 (load-file "example-syntax-error.el")
 
 (ert-deftest vanilla-leap-year ()

--- a/tests/example-syntax-error/example-syntax-error-test.el
+++ b/tests/example-syntax-error/example-syntax-error-test.el
@@ -3,7 +3,6 @@
 ;;; Commentary:
 
 ;;; Code:
-
 (load-file "example-syntax-error.el")
 
 (ert-deftest vanilla-leap-year ()

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "status": "error",
-  "message": "Loading /solution/example-syntax-error.el (source)...\r\nDebugger entered--Lisp error: (void-variable DEF&*@)\r\n  eval-buffer(#<buffer  > nil \"/solution/exampl...\" nil t)  ; Reading at buffer position 41\r\n  load-with-code-conversion(\"/solution/exampl...\" \"/solution/exampl...\" nil nil)\r\n  load(\"/solution/exampl...\" nil nil t)\r\n  load-file(\"example-syntax-error.el\")\r\n  eval-buffer(#<buffer  > nil \"/solution/exampl...\" nil t)  ; Reading at buffer position 151\r\n  load-with-code-conversion(\"/solution/exampl...\" \"/solution/exampl...\" nil t)\r\n  load(\"/solution/exampl...\" nil t)\r\n  command-line-1((\"-l\" \"ert\" \"-l\" \"/solution/exampl...\" \"-f\" \"ert-run-tests-batch-and-exit\"))\r\n  command-line()\r\n  normal-top-level()\r\n\r",
+  "message": "Loading /solution/example-syntax-error.el (source)...\r\nSymbol's value as variable is void: DEF&*@\r",
   "tests": [
     {
       "name": "vanilla-leap-year",

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "status": "error",
-  "message": "Loading /solution/example-syntax-error.el (source)...\r\nSymbol's value as variable is void: DEF&*@\r",
+  "message": "Loading /solution/example-syntax-error.el (source)...\r\n\r\nError: void-variable (DEF&*@)\r\n  mapbacktrace(#f(compiled-function (evald func args flags) #<bytecode >))\r\n  debug-early-backtrace()\r\n  debug-early(error (void-variable DEF&*@))\r\n  eval-buffer(#<buffer  > nil \"/solution/example-syntax-error.el\" nil t)\r\n  load-with-code-conversion(\"/solution/example-syntax-error.el\" \"/solution/example-syntax-error.el\" nil nil)\r\n  load(\"/solution/example-syntax-error.el\" nil nil t)\r\n  load-file(\"example-syntax-error.el\")\r\n  eval-buffer(#<buffer  > nil \"/solution/example-syntax-error-test.el\" nil t)\r\n  load-with-code-conversion(\"/solution/example-syntax-error-test.el\" \"/solution/example-syntax-error-test.el\" nil t)\r\n  load(\"/solution/example-syntax-error-test.el\" nil t)\r\n  command-line-1((\"-l\" \"ert\" \"-l\" \"/solution/example-syntax-error-test.el\" \"-f\" \"ert-run-tests-batch-and-exit\"))\r\n  command-line()\r\n  normal-top-level()\r\nSymbol's value as variable is void: DEF&*@\r",
   "tests": [
     {
       "name": "vanilla-leap-year",


### PR DESCRIPTION
The backtrace for the example-syntax-error-test had to be deactivated because of changes introduced in Emacs 29.
Emacs 29 introduced [debug-early.el](https://github.com/emacs-mirror/emacs/blob/2c201bbba5c43328979bf139330684cacfa074f3/lisp/emacs-lisp/debug-early.el) which is always run in batch mode.
The [lambda](https://github.com/emacs-mirror/emacs/blob/2c201bbba5c43328979bf139330684cacfa074f3/lisp/emacs-lisp/debug-early.el#L60) in the code produces a changing bytecode hash output in the backtrace, so matching with the expected message via `diff` failed.

---

The change to the test is not great, I've asked on [Emacs Stackexchange](https://emacs.stackexchange.com/questions/81515/emacs-29-ert-batch-run-error-output-changes-between-runs-because-of-debug-early) for a better solution. Alternatively we could somehow ignore the changing part of the backtrace in [run-tests.sh](https://github.com/exercism/emacs-lisp-test-runner/blob/767b83c5416cf60050db17716ebbae127eab02b8/bin/run-tests.sh#L36).

@ErikSchierboom Are there examples in other test runners where the output message is not deterministic?