### PR TITLE
Switch container to Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM silex/emacs:30.1
+FROM silex/emacs:30.1-alpine
 
-RUN apt-get update && \
-    apt-get install -y curl jq software-properties-common
+RUN apk update && \
+    apk add curl \
+            jq \
+            bash \
+            python3 \
+            util-linux
 
-RUN rm -rf /var/lib/apt/lists/* && \
-    apt-get purge --auto-remove && \
-    apt-get clean
+RUN rm /var/cache/apk/*
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -26,7 +26,7 @@ script_dir="$(dirname "$0")"
 input_dir="${2%/}"
 output_dir="${3%/}"
 test_file="${input_dir}/${slug}-test.el"
-test_output_file="$(mktemp --suffix ".out")"
+test_output_file="$(mktemp)"
 results_file="${output_dir}/results.json"
 
 # Create the output directory if it doesn't exist

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "status": "fail",
-  "message": "Loading /solution/example-all-fail.el (source)...\r\nRunning 5 tests \r\n\r\n5 unexpected results:\r\n   \u001b[01;31m\u001b[KFAILED  any-old-year\r\u001b[m\u001b[K\n   \u001b[01;31m\u001b[KFAILED  century\r\u001b[m\u001b[K\n   \u001b[01;31m\u001b[KFAILED  exceptional-century\r\u001b[m\u001b[K\n   \u001b[01;31m\u001b[KFAILED  non-leap-even-year\r\u001b[m\u001b[K\n   \u001b[01;31m\u001b[KFAILED  vanilla-leap-year\r\u001b[m\u001b[K\n\r",
+  "message": "Loading /solution/example-all-fail.el (source)...\r\nRunning 5 tests \r\n\r\n5 unexpected results:\r\n   FAILED  any-old-year\r\n   FAILED  century\r\n   FAILED  exceptional-century\r\n   FAILED  non-leap-even-year\r\n   FAILED  vanilla-leap-year\r\n\r",
   "tests": [
     {
       "name": "vanilla-leap-year",

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "status": "error",
-  "message": "Loading /solution/example-empty-file.el (source)...\r\nRunning 5 tests \r\n\r\n5 unexpected results:\r\n   \u001b[01;31m\u001b[KFAILED  any-old-year\r\u001b[m\u001b[K\n   \u001b[01;31m\u001b[KFAILED  century\r\u001b[m\u001b[K\n   \u001b[01;31m\u001b[KFAILED  exceptional-century\r\u001b[m\u001b[K\n   \u001b[01;31m\u001b[KFAILED  non-leap-even-year\r\u001b[m\u001b[K\n   \u001b[01;31m\u001b[KFAILED  vanilla-leap-year\r\u001b[m\u001b[K\n\r",
+  "message": "Loading /solution/example-empty-file.el (source)...\r\nRunning 5 tests \r\n\r\n5 unexpected results:\r\n   FAILED  any-old-year\r\n   FAILED  century\r\n   FAILED  exceptional-century\r\n   FAILED  non-leap-even-year\r\n   FAILED  vanilla-leap-year\r\n\r",
   "tests": [
     {
       "name": "vanilla-leap-year",

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "status": "fail",
-  "message": "Loading /solution/example-partial-fail.el (source)...\r\nRunning 5 tests \r\n\r\n1 unexpected results:\r\n   \u001b[01;31m\u001b[KFAILED  exceptional-century\r\u001b[m\u001b[K\n\r",
+  "message": "Loading /solution/example-partial-fail.el (source)...\r\nRunning 5 tests \r\n\r\n1 unexpected results:\r\n   FAILED  exceptional-century\r\n\r",
   "tests": [
     {
       "name": "vanilla-leap-year",


### PR DESCRIPTION
- reduces the Docker image size by 266MB
- there seems to be a ~5% performance hit on my machine

Depends on https://github.com/exercism/emacs-lisp-test-runner/pull/83 (sort of incidental, but the other PR is more important anyways)

---

Not sure if this is worth it, but the [performance guide](https://exercism.org/docs/building/tooling/best-practices#h-experiment-with-different-base-images) says to prefer smaller image sizes given comparable performance.